### PR TITLE
Handle data after a closing directive, ala <foo bar> doof </foo bar>

### DIFF
--- a/simpleconf.go
+++ b/simpleconf.go
@@ -382,7 +382,16 @@ func parseInclude(state *parser, line string) (Config, error) {
 }
 
 var blockRegex = regexp.MustCompile(`^\s*<\s*(\w+)\s*(.+?)?\s*>\s*$`) // ugly regexp :(
-var closeRegex = regexp.MustCompile(`^\s*</\s*(\w+)\s*>\s*$`)
+// note the extra (?:\w+\s*)? -- this is needed because it is a common mistake to
+// do this:
+// <foo bar>
+//   baz
+// </foo bar>
+//
+// With an extraneous 'bar' after the closing </foo>.  Correctness says
+// we should reject this, but most simpleconf parsers (e.g. Perl's) just
+// silently accept it.
+var closeRegex = regexp.MustCompile(`^\s*</\s*(\w+)\s*(?:\w+\s*)?>\s*$`)
 
 // <foo bar>
 // baz qux

--- a/simpleconf_test.go
+++ b/simpleconf_test.go
@@ -141,6 +141,41 @@ perms 0700
 		},
 	},
 	{
+		// kv blocks with extra data after the closing directive
+		`
+<dir dir1> # ignore this comment
+foo1 bar1 # this one too
+baz1 qux1
+</dir dir1>
+
+<Dir Dir2>
+foo2 bar2
+baz2 qux2
+<file file1>
+perms 0700
+</file filebar>
+</Dir Dir2>
+`,
+
+		map[string]interface{}{
+			"dir": map[string]interface{}{
+				"dir1": map[string]interface{}{
+					"foo1": "bar1",
+					"baz1": "qux1",
+				},
+				"Dir2": map[string]interface{}{
+					"foo2": "bar2",
+					"baz2": "qux2",
+					"file": map[string]interface{}{
+						"file1": map[string]interface{}{
+							"perms": "0700",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		// unnamed blocks
 		`
 <dir>


### PR DESCRIPTION
Short & sweet:

```
<foo bar>
  doof
</foo bar>
```

Is a very common mistake to make, and other simpleconf-style parsers just ignore the extra 'bar', so this makes this package follow suit.